### PR TITLE
Fix/academia

### DIFF
--- a/academia.wlk
+++ b/academia.wlk
@@ -37,7 +37,10 @@ object academia {
   }
   // Entrenar un mago
   method entrenarMagoDeEquipo(unMago){
-    unMago.entrenar()
+    if (equipoDeMagos.contains(unMago)){
+      unMago.entrenar()
+    }
+    
   }
 
   // También agregamos la posibilidad de entrenar a todos AL MISMO TIEMPO

--- a/academia.wlk
+++ b/academia.wlk
@@ -52,7 +52,7 @@ object academia {
   }
 
   method listaDePoderes(){
-    return equipoDeMagos.map({m => m.poder()}).filter({p => p > 90})
+    return equipoDeMagos.filter({m => m.energia()>90}).map({m => m.poder()})
 
   }
 }

--- a/academia.wlk
+++ b/academia.wlk
@@ -5,54 +5,54 @@ métodos: reclutar, poderTotal, deltaEnergia, ...
 
 import magos.*
 object academia {
-  const equipo = []
-  const candidatos = []
-  //verificar que su energía mágica sea mayor a 40 y su poder igual o superior a 30.
-  method cumpleConRequisitos(unMago) = self.cumpleConEnergiaApropiada(
-    unMago
-  ) && self.cumpleConPoderApropiado(unMago)
+  const equipoDeMagos = []
+  const listaDeCandidatos = []
   
-  // Reclutar un mago (si cumple entra al equipo, si no a candidatos)
-  method reclutar(unMago) {
-    if (self.cumpleConRequisitos(unMago)) equipo.add(unMago)
-    else candidatos.add(unMago)
+  // necesito los getters para consultar en los test
+  method equipoDeMagos() {
+    return equipoDeMagos    
+  }
+  method listaDeCandidatos() {
+    return listaDeCandidatos
   }
   
-  // Re-evaluar candidatos: los que cumplen pasan al equipo
-  method reevaluarCandidatos() {
-    var nuevosMiembros = []
-    nuevosMiembros = candidatos.filter({ c => self.cumpleConRequisitos(c)})
-    
-    nuevosMiembros.forEach({ c => equipo.add(c)})
-    
-    nuevosMiembros.forEach({ c => candidatos.remove(c)})
+  
+  method reclutar(unMago){
+    if (unMago.energia()>40 and unMago.poder()>= 30){
+      self.adicionarAlEquipo(unMago)
+    }
+    else{
+      listaDeCandidatos.add(unMago)
+    }
   }
-  
-  method cumpleConEnergiaApropiada(unMago) = unMago.energia() > 40
-  
-  method cumpleConPoderApropiado(unMago) = unMago.poder() >= 30
-  
+
+  method adicionarAlEquipo(unMago){
+    if (listaDeCandidatos.contains(unMago)){
+      listaDeCandidatos.remove(unMago)
+      equipoDeMagos.add(unMago)
+    }
+    else{
+      equipoDeMagos.add(unMago)
+    }
+  }
+
   // Entrenar a todos los del equipo
   method entrenarEquipo() {
     equipo.forEach({ m => m.entrenar()})
   }
-  
-  // Poder total del equipo
-  method poderTotal() = equipo.sum({ m => m.poder()})
-  
-  // ¿Condiciones óptimas? (nadie con energía < 45)
-  method condicionesOptimas() = equipo.all({ m => m.energia() >= 45})
-  
-  // Delta de energía (máxima - mínima, en valor absoluto)
-  method deltaEnergia() {
-    var magoConMaximaEnergia = equipo.max({ m => m.energia()})
-    var magoConMinimaEnergia = equipo.min({ m => m.energia()})
-    return (magoConMaximaEnergia.energia() - magoConMinimaEnergia.energia()).abs()
+  method poderTotalDelEquipo(){
+    return equipoDeMagos.sum({m => m.poder()})
   }
-  
-  // Lista de poderes de magos con energía > 90
-  method poderesDeMagosConAltaEnergia() {
-    var magosConMasDe90DeEnergia = equipo.filter({ m => m.energia() > 90 })
-    return magosConMasDe90DeEnergia.map({ m => m.poder()})
+  method elEquipoEstaOptimo(){
+    return not equipoDeMagos.any({m => m.energia() < 45})
+  }
+  method deltaEnergia(){
+    return (self.equipoDeMagos().max({m => m.poder()}) - self.equipoDeMagos().min({m => m.poder()})).abs()
+    
+  }
+
+  method listaDePoderes(){
+    return equipoDeMagos.filter({m => m.poder()>90})
+
   }
 }

--- a/academia.wlk
+++ b/academia.wlk
@@ -52,7 +52,7 @@ object academia {
   }
 
   method listaDePoderes(){
-    return equipoDeMagos.filter({m => m.poder()>90})
+    return equipoDeMagos.map({m => m.poder()}).filter({p => p > 90})
 
   }
 }

--- a/academia.wlk
+++ b/academia.wlk
@@ -35,8 +35,12 @@ object academia {
       equipoDeMagos.add(unMago)
     }
   }
+  // Entrenar un mago
+  method entrenar(unMago){
+    unMago.entrenar()
+  }
 
-  // Entrenar a todos los del equipo
+  // También agregamos la posibilidad de entrenar a todos AL MISMO TIEMPO
   method entrenarEquipo() {
     equipoDeMagos.forEach({ m => m.entrenar()})
   }

--- a/academia.wlk
+++ b/academia.wlk
@@ -40,6 +40,9 @@ object academia {
     if (equipoDeMagos.contains(unMago)){
       unMago.entrenar()
     }
+    else{
+      return "Sólo se puede entrenar un mago del equipo"
+    }
     
   }
 

--- a/academia.wlk
+++ b/academia.wlk
@@ -36,7 +36,7 @@ object academia {
     }
   }
   // Entrenar un mago
-  method entrenar(unMago){
+  method entrenarMagoDeEquipo(unMago){
     unMago.entrenar()
   }
 

--- a/magos.wlk
+++ b/magos.wlk
@@ -61,7 +61,8 @@ object iris {
   // se inicio capacidadDeSanacion en 1 porque si inicia en 2 no se puede testear con lo que piden
   var capacidadDeSanacion = 1
   //pero cunado entrena
-   
+  method energia() = energia
+  method poder() = poder
   method entrenar() {
    // cada vez que entrena su capcidad de sanacion aumenta en 1
     capacidadDeSanacion += 1


### PR DESCRIPTION
Hola equipo, ¿cómo andan? Ayer estuve afuera todo el día, por lo que no puede aportar a academia. Ahora pude comarar side-to-side. Me parece que se crean métodos de más, un ejemplo es `method cumpleConRequisitos(unMago)` . Puedo crear el método? Puedo. Me salva del if? No. Entonces si entra todo en un sólo método que es reclutar(unMago), por qué no ir por dicha vía más directa?

Además con la estrategia utilizada, se utiliza el método `method reevaluarCandidatos()`. 

Propuesta: canjear 3 métodos: `method cumpleConRequisitos(unMago)` , `method reevaluarCandidatos()`, `method reclutar(unMago)`  por un único

 ```
method reclutar(unMago){
    if (unMago.energia()>40 and unMago.poder()>= 30){
      self.adicionarAlEquipo(unMago)
    }
    else{
      listaDeCandidatos.add(unMago)
    }
  }
```

También se propone un cambio en la lógica de reevaluar candidatos. Del enunciado, en ningún momento dice que la academia evalua a TODOS los candidatos de la lista. Dice que tiene la potestad de volver a evaluar un mago eventualmente. En la versión propuesta los métodos reflejan eso. Cuando quiere, la academia evalúa al mago que quiere (otra vez) y este puede pasar al equipo. Esto entiendo es una interpretación de enunciado.

Obviamente esto altera todo el código, de ahí que el PR sobreescriba la versión actual de academia.